### PR TITLE
Refactor package prefix to solutions.fairdata

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.fair.openrefine</groupId>
+    <groupId>solutions.fairdata.openrefine</groupId>
     <artifactId>metadata</artifactId>
     <version>0.1.0-SNAPSHOT</version>
     <packaging>jar</packaging>

--- a/src/main/java/solutions/fairdata/openrefine/metadata/commands/ConnectFDPCommand.java
+++ b/src/main/java/solutions/fairdata/openrefine/metadata/commands/ConnectFDPCommand.java
@@ -20,14 +20,14 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.fair.openrefine.metadata.commands;
+package solutions.fairdata.openrefine.metadata.commands;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.google.refine.commands.Command;
 import com.google.refine.util.ParsingUtilities;
 
 import nl.dtl.fairmetadata4j.model.FDPMetadata;
-import org.fair.openrefine.metadata.fdp.FairDataPointClient;
+import solutions.fairdata.openrefine.metadata.fdp.FairDataPointClient;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;

--- a/src/main/java/solutions/fairdata/openrefine/metadata/example/SampleUtil.java
+++ b/src/main/java/solutions/fairdata/openrefine/metadata/example/SampleUtil.java
@@ -20,18 +20,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.fair.openrefine.metadata.example;
+package solutions.fairdata.openrefine.metadata.example;
 
-import org.junit.jupiter.api.Test;
+public class SampleUtil {
+    // Just an example file
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
-
-public class SampleUtilTest {
-    // Just an example test file
-
-    @Test
-    public void testSampleMethod() {
-        assertEquals(42, SampleUtil.sampleMethod());
+    static public int sampleMethod() {
+        return 42;
     }
 }

--- a/src/main/java/solutions/fairdata/openrefine/metadata/fdp/FairDataPointClient.java
+++ b/src/main/java/solutions/fairdata/openrefine/metadata/fdp/FairDataPointClient.java
@@ -20,7 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.fair.openrefine.metadata.fdp;
+package solutions.fairdata.openrefine.metadata.fdp;
 
 
 import nl.dtl.fairmetadata4j.model.FDPMetadata;

--- a/src/main/java/solutions/fairdata/openrefine/metadata/fdp/FairDataPointException.java
+++ b/src/main/java/solutions/fairdata/openrefine/metadata/fdp/FairDataPointException.java
@@ -20,7 +20,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.fair.openrefine.metadata.fdp;
+package solutions.fairdata.openrefine.metadata.fdp;
 
 public class FairDataPointException extends Exception {
 

--- a/src/main/resources/module/MOD-INF/controller.js
+++ b/src/main/resources/module/MOD-INF/controller.js
@@ -1,9 +1,9 @@
 /*
  * Main JS file for FAIR Metadata extension of OpenRefine
  */
-/* global importPackage, module, org, Packages, ConnectFDPCommand, ClientSideResourceManager */
+/* global importPackage, module, solutions, Packages, ConnectFDPCommand, ClientSideResourceManager */
 /* eslint-disable no-unused-vars */
-importPackage(org.fair.openrefine.metadata.commands);
+importPackage(solutions.fairdata.openrefine.metadata.commands);
 
 function init() {
     var RefineServlet = Packages.com.google.refine.RefineServlet;

--- a/src/test/java/solutions/fairdata/openrefine/metadata/example/SampleUtilTest.java
+++ b/src/test/java/solutions/fairdata/openrefine/metadata/example/SampleUtilTest.java
@@ -20,12 +20,18 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package org.fair.openrefine.metadata.example;
+package solutions.fairdata.openrefine.metadata.example;
 
-public class SampleUtil {
-    // Just an example file
+import org.junit.jupiter.api.Test;
 
-    static public int sampleMethod() {
-        return 42;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+public class SampleUtilTest {
+    // Just an example test file
+
+    @Test
+    public void testSampleMethod() {
+        assertEquals(42, SampleUtil.sampleMethod());
     }
 }


### PR DESCRIPTION
As follow-up to #1, it was decided that Java packages should have prefix `solutions.fairdata`.