### PR TITLE
[FOR-39] Enable getting form specs from FDP

### DIFF
--- a/src/main/java/solutions/fairdata/openrefine/metadata/commands/MetadataSpecsCommand.java
+++ b/src/main/java/solutions/fairdata/openrefine/metadata/commands/MetadataSpecsCommand.java
@@ -1,0 +1,65 @@
+/**
+ * The MIT License
+ * Copyright © 2019 FAIR Data Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package solutions.fairdata.openrefine.metadata.commands;
+
+import com.google.refine.commands.Command;
+import solutions.fairdata.openrefine.metadata.commands.response.ErrorResponse;
+import solutions.fairdata.openrefine.metadata.commands.response.metadata.MetadataSpecResponse;
+import solutions.fairdata.openrefine.metadata.fdp.FairDataPointClient;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.Writer;
+
+public class MetadataSpecsCommand extends Command {
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        String fdpUri = request.getParameter("fdpUri");
+        String token = request.getParameter("token");
+        String type = request.getParameter("type");
+        Writer w = CommandUtils.prepareWriter(response);
+        FairDataPointClient fdpClient = new FairDataPointClient(fdpUri, token, logger);
+
+        try {
+            Object result;
+            if ("catalog".equalsIgnoreCase(type)) {
+                result = fdpClient.getCatalogSpec();
+            } else if ("dataset".equalsIgnoreCase(type)) {
+                result = fdpClient.getDatasetSpec();
+            } else if ("distribution".equalsIgnoreCase(type)) {
+                result = fdpClient.getDistributionSpec();
+            } else {
+                throw new IOException("Invalid metadata type requested");
+            }
+            CommandUtils.objectMapper.writeValue(w, new MetadataSpecResponse(result));
+        } catch (Exception e) {
+            logger.error("Error while getting dashboard: " + fdpUri + " (" + e.getMessage() + ")");
+            CommandUtils.objectMapper.writeValue(w, new ErrorResponse("connect-fdp-command/error", e));
+        } finally {
+            w.flush();
+            w.close();
+        }
+    }
+}

--- a/src/main/java/solutions/fairdata/openrefine/metadata/commands/response/metadata/MetadataSpecResponse.java
+++ b/src/main/java/solutions/fairdata/openrefine/metadata/commands/response/metadata/MetadataSpecResponse.java
@@ -1,0 +1,43 @@
+/**
+ * The MIT License
+ * Copyright © 2019 FAIR Data Team
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package solutions.fairdata.openrefine.metadata.commands.response.metadata;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class MetadataSpecResponse {
+
+    public String status;
+    public Object spec;
+
+    public MetadataSpecResponse(Object spec) {
+        this.status = "ok";
+        this.spec = spec;
+    }
+}

--- a/src/main/java/solutions/fairdata/openrefine/metadata/fdp/FairDataPointClient.java
+++ b/src/main/java/solutions/fairdata/openrefine/metadata/fdp/FairDataPointClient.java
@@ -78,6 +78,13 @@ public class FairDataPointClient {
             308   // HTTP Permanent Redirect
     ));
 
+    private static final String CATALOG_PART = "/catalog";
+    private static final String DATASET_PART = "/dataset";
+    private static final String DISTRIBUTION_PART = "/distribution";
+    private static final String SPEC_PART = "/spec";
+    private static final String AUTH_PART = "/tokens";;
+    private static final String DASHBOARD_PART = "/dashboard";
+
     private static final String USER_AGENT = MetadataModuleImpl.USER_AGENT;
 
     private final Logger logger;
@@ -97,7 +104,7 @@ public class FairDataPointClient {
     // AUTH TOKEN
 
     public TokenDTO postAuthentication(AuthDTO auth) throws IOException, FairDataPointException {
-        HttpURLConnection conn = createConnection(fdpBaseURI + "/tokens", "POST", "application/json");
+        HttpURLConnection conn = createConnection(fdpBaseURI + AUTH_PART, "POST", "application/json");
         conn.addRequestProperty("Content-Type", "application/json; utf-8");
         conn.setDoOutput(true);
         objectMapper.writeValue(conn.getOutputStream(), auth);
@@ -112,7 +119,7 @@ public class FairDataPointClient {
     // DASHBOARD
 
     public List<DashboardCatalogDTO> getDashboard() throws IOException, FairDataPointException {
-        HttpURLConnection conn = request(fdpBaseURI + "/fdp/dashboard", "GET", "application/json", true);
+        HttpURLConnection conn = request(fdpBaseURI + DASHBOARD_PART, "GET", "application/json", true);
 
         if(conn.getResponseCode() == HttpURLConnection.HTTP_OK) {
             return objectMapper.readValue(conn.getInputStream(), new TypeReference<List<DashboardCatalogDTO>>(){});
@@ -191,10 +198,34 @@ public class FairDataPointClient {
         }
     }
 
+    // GET Spects
+
+    public Object getCatalogSpec() throws IOException, FairDataPointException {
+        return getMetadataSpec(CATALOG_PART);
+    }
+
+    public Object getDatasetSpec() throws IOException, FairDataPointException {
+        return getMetadataSpec(DATASET_PART);
+    }
+
+    public Object getDistributionSpec() throws IOException, FairDataPointException {
+        return getMetadataSpec(DISTRIBUTION_PART);
+    }
+
+    private Object getMetadataSpec(String metadataPart) throws IOException, FairDataPointException {
+        HttpURLConnection conn = request(fdpBaseURI + metadataPart + SPEC_PART, "GET", "application/json", true);
+
+        if(conn.getResponseCode() == HttpURLConnection.HTTP_OK) {
+            return objectMapper.readValue(conn.getInputStream(), Object.class);
+        } else {
+            throw new FairDataPointException(conn.getResponseCode(), conn.getResponseMessage());
+        }
+    }
+
     // POST
 
     public CatalogDTO postCatalog(CatalogDTO catalogDTO) throws IOException, MetadataException, FairDataPointException {
-        HttpURLConnection conn = createConnection(fdpBaseURI + "/fdp/catalog", "POST", "text/turtle");
+        HttpURLConnection conn = createConnection(fdpBaseURI + CATALOG_PART, "POST", "text/turtle");
         conn.addRequestProperty("Content-Type", "text/turtle");
         conn.setDoOutput(true);
 
@@ -227,7 +258,7 @@ public class FairDataPointClient {
     }
 
     public DatasetDTO postDataset(DatasetDTO datasetDTO) throws IOException, MetadataException, FairDataPointException {
-        HttpURLConnection conn = createConnection(fdpBaseURI + "/fdp/dataset", "POST", "text/turtle");
+        HttpURLConnection conn = createConnection(fdpBaseURI + DATASET_PART, "POST", "text/turtle");
         conn.addRequestProperty("Content-Type", "text/turtle");
         conn.setDoOutput(true);
 
@@ -260,7 +291,7 @@ public class FairDataPointClient {
     }
 
     public DistributionDTO postDistribution(DistributionDTO distributionDTO) throws IOException, MetadataException, FairDataPointException {
-        HttpURLConnection conn = createConnection(fdpBaseURI + "/fdp/distribution", "POST", "text/turtle");
+        HttpURLConnection conn = createConnection(fdpBaseURI + DISTRIBUTION_PART, "POST", "text/turtle");
         conn.addRequestProperty("Content-Type", "text/turtle");
         conn.setDoOutput(true);
 

--- a/src/main/resources/module/MOD-INF/controller.js
+++ b/src/main/resources/module/MOD-INF/controller.js
@@ -15,6 +15,7 @@ function init() {
     RefineServlet.registerCommand(module, "catalogs-metadata", new MetadataCommands.CatalogsMetadataCommand());
     RefineServlet.registerCommand(module, "datasets-metadata", new MetadataCommands.DatasetsMetadataCommand());
     RefineServlet.registerCommand(module, "distributions-metadata", new MetadataCommands.DistributionsMetadataCommand());
+    RefineServlet.registerCommand(module, "metadata-specs", new MetadataCommands.MetadataSpecsCommand());
     RefineServlet.registerCommand(module, "typehints", new MetadataCommands.TypehintsCommand());
     RefineServlet.registerCommand(module, "store-data", new MetadataCommands.StoreDataCommand());
 

--- a/src/main/resources/module/scripts/api-client.js
+++ b/src/main/resources/module/scripts/api-client.js
@@ -33,12 +33,12 @@ class MetadataApiClient {
     }
 
     getFDPMetadata(callbacks, errorCallbacks) {
-        const params = { fdpUri: this.fdpUri};
+        const params = { fdpUri: this.fdpUri };
         this._ajaxGeneric("fdp-metadata", "GET", params, callbacks, errorCallbacks);
     }
 
     getCatalogs(callbacks, errorCallbacks) {
-        const params = { fdpUri: this.fdpUri};
+        const params = { fdpUri: this.fdpUri };
         this._ajaxGeneric("catalogs-metadata", "GET", params, callbacks, errorCallbacks);
     }
 
@@ -52,27 +52,44 @@ class MetadataApiClient {
         this._ajaxGeneric("distributions-metadata", "GET", params, callbacks, errorCallbacks);
     }
 
+    getCatalogSpec(callbacks, errorCallbacks) {
+        this.getMetadataSpec("catalog", callbacks, errorCallbacks);
+    }
+
+    getDatasetSpec(callbacks, errorCallbacks) {
+        this.getMetadataSpec("dataset", callbacks, errorCallbacks);
+    }
+
+    getDistributionSpec(callbacks, errorCallbacks) {
+        this.getMetadataSpec("distribution", callbacks, errorCallbacks);
+    }
+
+    getMetadataSpec(type, callbacks, errorCallbacks) {
+        const params = { fdpUri: this.fdpUri, token: this.token, type };
+        this._ajaxGeneric("metadata-specs", "GET", params, callbacks, errorCallbacks);
+    }
+
     getTypehints(name, query, callbacks, errorCallbacks) {
         this._ajaxGeneric("typehints", "GET", { name, query }, callbacks, errorCallbacks, true);
     }
 
     postCatalog(catalog, callbacks, errorCallbacks) {
         const catalogPostRequest = JSON.stringify({
-            fdpUri: this.fdpUri, token: this. token, catalog
+            fdpUri: this.fdpUri, token: this.token, catalog
         });
         this._ajaxGeneric("catalogs-metadata", "POST", catalogPostRequest, callbacks, errorCallbacks);
     }
 
     postDataset(dataset, callbacks, errorCallbacks) {
         const datasetPostRequest = JSON.stringify({
-            fdpUri: this.fdpUri, token: this. token, dataset
+            fdpUri: this.fdpUri, token: this.token, dataset
         });
         this._ajaxGeneric("datasets-metadata", "POST", datasetPostRequest, callbacks, errorCallbacks);
     }
 
     postDistribution(distribution, callbacks, errorCallbacks) {
         const distributionPostRequest = JSON.stringify({
-            fdpUri: this.fdpUri, token: this. token, distribution
+            fdpUri: this.fdpUri, token: this.token, distribution
         });
         this._ajaxGeneric("distributions-metadata", "POST", distributionPostRequest, callbacks, errorCallbacks);
     }

--- a/src/main/resources/module/scripts/dialogs/metadata-form-dialog.js
+++ b/src/main/resources/module/scripts/dialogs/metadata-form-dialog.js
@@ -7,7 +7,7 @@ class MetadataFormDialog {
         this.level = null;
 
         this.type = type;
-        this.specs = specs;
+        this.specs = specs; // TODO: in the future, get specs from FDP API (client prepared)
         this.callbackFn = callbackFn;
         this.apiClient = new MetadataApiClient();
 


### PR DESCRIPTION
This allows to get form specs from FDP, it is prepared in backend and frontend client but not yet used to actually build forms. FDP currently serves specs that does not cover all fields that needs to be present in the *metadata* extension.